### PR TITLE
add xorg-server-xvfb

### DIFF
--- a/manifest
+++ b/manifest
@@ -179,6 +179,7 @@ export PACKAGES="\
 	xdg-user-dirs-gtk \
 	xf86-video-amdgpu \
 	xorg-server \
+	xorg-server-xvfb \
 	xz \
 	zip \
 	zram-generator \


### PR DESCRIPTION
GUI applications (like Easy Effects) requires X. To run them headlessly in Game Mode, Xvfb can be used instead of a full X session, making it possible to work as services in the background.

For example:
```shell
Xvfb :43 &
export DISPLAY=:43
flatpak run --command=easyeffects com.github.wwmm.easyeffects --gapplication-service &
```